### PR TITLE
Fix for newer version of ruby

### DIFF
--- a/partitions.rb
+++ b/partitions.rb
@@ -86,7 +86,7 @@ if Facter.value(:kernel) == 'Linux'
     end
 
     # Convert back into a string value ...
-    disk = disk.to_s
+    disk = disk.first.to_s
 
     # We have something rather odd that did not parse at all, so ignore ...
     next if disk.empty?


### PR DESCRIPTION
to_s converts Array with backquotes in latests versions of ruby

``` bash
$ ruby -v           
ruby 1.8.7 (2011-06-30 patchlevel 352) [x86_64-linux]
$ irb
irb(main):001:0> ["sda"].to_s
=> "sda"
irb(main):002:0> ["sda"].first.to_s
=> "sda"



$ ruby -v
ruby 1.9.3p392 (2013-02-22 revision 39386) [x86_64-linux]
$ irb
irb(main):001:0> ["sda"].to_s
=> "[\"sda\"]"
irb(main):001:0> ["sda"].first.to_s
=> "sda"
```
