### PR TITLE
Exclude device mapper devices without excluding /dev/sdm

### DIFF
--- a/partitions.rb
+++ b/partitions.rb
@@ -30,7 +30,7 @@ if Facter.value(:kernel) == 'Linux'
   # MMC is Multi Media Card which can be either SD or microSD, etc ...
   # MTD is Memory Technology Device also known as Flash Memory
   #
-  exclude = %w(backdev.* dm loop md mmcblk mtdblock ramzswap)
+  exclude = %w(backdev.* dm-\d loop md mmcblk mtdblock ramzswap)
 
   #
   # Modern Linux kernels provide "/proc/partitions" in the following format:


### PR DESCRIPTION
Presently /dev/sdm is excluded because "dm" is in the exclude string. This fixes it.
